### PR TITLE
Removes legacy node-gyp binary

### DIFF
--- a/pkgs/npm-9_x/default.nix
+++ b/pkgs/npm-9_x/default.nix
@@ -13,7 +13,7 @@ pkgs.stdenv.mkDerivation rec {
   installPhase = ''
     mkdir $out
     cp -r * $out
-    chmod +x $out/bin/{npm,npx,node-gyp-bin/node-gyp}
+    chmod +x $out/bin/{npm,npx}
   '';
   meta.priority = "100"; # Prevents collision with Node's built-in npm
 }


### PR DESCRIPTION
I didn't notice that the old reference to node-gyp binaries [was removed](https://github.com/npm/cli/pull/6554). This PR fixes that